### PR TITLE
fix(payments): defer payment gateway hook registration to avoid freezing gateway list

### DIFF
--- a/includes/TaskCompletionTriggers.php
+++ b/includes/TaskCompletionTriggers.php
@@ -137,16 +137,12 @@ class TaskCompletionTriggers {
 	 */
 	private function register_payment_hooks_and_validators(): void {
 
-		// Payment method configuration - hook into payment gateway settings updates
-		if ( class_exists( '\WC_Payment_Gateways' ) ) {
-			$gateways = \WC_Payment_Gateways::instance()->get_payment_gateway_ids();
-
-			foreach ( $gateways as $gateway_id ) {
-				add_action( "update_option_woocommerce_{$gateway_id}_settings", array( __CLASS__, 'on_payment_gateway_updated' ) );
-			}
-		}
-
-		// Also hook into individual payment gateway updates for better coverage
+		// Defer all gateway hook registration to init priority 20, which is safely
+		// after woocommerce_init (init priority 0). Calling WC_Payment_Gateways::instance()
+		// any earlier forces WooCommerce to freeze its gateway list before third-party
+		// gateway plugins (e.g. Stripe, Braintree) have registered via the
+		// woocommerce_payment_gateways filter, causing those gateways to be permanently
+		// excluded. See PRESS0-4235.
 		\add_action( 'init', array( __CLASS__, 'register_payment_gateway_hooks' ), 20 );
 
 		TaskStateValidator::register_validator(
@@ -424,8 +420,8 @@ class TaskCompletionTriggers {
 
 		// Register hooks for each individual payment gateway
 		foreach ( $available_gateways as $gateway_id => $gateway ) {
-			$hook_name = "woocommerce_update_options_payment_gateways_{$gateway_id}";
-			\add_action( $hook_name, array( __CLASS__, 'on_payment_gateway_updated' ), 10 );
+			\add_action( "woocommerce_update_options_payment_gateways_{$gateway_id}", array( __CLASS__, 'on_payment_gateway_updated' ), 10 );
+			\add_action( "update_option_woocommerce_{$gateway_id}_settings", array( __CLASS__, 'on_payment_gateway_updated' ) );
 		}
 	}
 

--- a/tests/wpunit/TaskCompletionTriggersWPUnitTest.php
+++ b/tests/wpunit/TaskCompletionTriggersWPUnitTest.php
@@ -679,6 +679,93 @@ class TaskCompletionTriggersWPUnitTest extends \Codeception\TestCase\WPTestCase 
 	}
 
 
+	/**
+	 * Test that register_payment_gateway_hooks registers both hook types for each gateway.
+	 *
+	 * Verifies that after calling register_payment_gateway_hooks(), both
+	 * woocommerce_update_options_payment_gateways_{id} and
+	 * update_option_woocommerce_{id}_settings hooks are registered
+	 * for each available gateway.
+	 *
+	 * @covers ::register_payment_gateway_hooks
+	 */
+	public function test_register_payment_gateway_hooks_registers_both_hook_types() {
+		$woocommerce_installed = $this->installWooCommerceForTest();
+
+		if ( ! $woocommerce_installed ) {
+			$this->markTestSkipped( 'Failed to install WooCommerce for testing.' );
+		}
+
+		if ( ! function_exists( 'WC' ) || ! WC() ) {
+			$this->markTestSkipped( 'WooCommerce is not available after installation.' );
+		}
+
+		// Call the method under test
+		TaskCompletionTriggers::register_payment_gateway_hooks();
+
+		// Get the list of registered gateways
+		$gateways = WC()->payment_gateways()->payment_gateways();
+		$this->assertNotEmpty( $gateways, 'WooCommerce should have at least one gateway registered.' );
+
+		// Verify both hook types are registered for each gateway
+		foreach ( $gateways as $gateway_id => $gateway ) {
+			$this->assertGreaterThan(
+				0,
+				has_action( "woocommerce_update_options_payment_gateways_{$gateway_id}", array( TaskCompletionTriggers::class, 'on_payment_gateway_updated' ) ),
+				"woocommerce_update_options_payment_gateways_{$gateway_id} hook should be registered."
+			);
+
+			$this->assertGreaterThan(
+				0,
+				has_action( "update_option_woocommerce_{$gateway_id}_settings", array( TaskCompletionTriggers::class, 'on_payment_gateway_updated' ) ),
+				"update_option_woocommerce_{$gateway_id}_settings hook should be registered."
+			);
+		}
+
+		$this->deactivateWooCommerceAfterTest();
+	}
+
+	/**
+	 * Test that the constructor does not force WC_Payment_Gateways to instantiate.
+	 *
+	 * This prevents the plugin from freezing WooCommerce's gateway list before
+	 * third-party gateway plugins have registered via the woocommerce_payment_gateways
+	 * filter. See PRESS0-4235.
+	 *
+	 * @covers ::__construct
+	 */
+	public function test_constructor_does_not_instantiate_payment_gateways_early() {
+		$woocommerce_installed = $this->installWooCommerceForTest();
+
+		if ( ! $woocommerce_installed ) {
+			$this->markTestSkipped( 'Failed to install WooCommerce for testing.' );
+		}
+
+		if ( ! class_exists( '\WC_Payment_Gateways' ) ) {
+			$this->markTestSkipped( 'WC_Payment_Gateways class is not available.' );
+		}
+
+		// Reset the WC_Payment_Gateways singleton so we can detect if it gets created
+		$ref  = new \ReflectionClass( '\WC_Payment_Gateways' );
+		$prop = $ref->getProperty( '_instance' );
+		$prop->setAccessible( true );
+		$prop->setValue( null );
+
+		// Construct TaskCompletionTriggers — this must NOT instantiate WC_Payment_Gateways
+		$container = new \stdClass();
+		new TaskCompletionTriggers( $container );
+
+		// Verify the singleton was NOT created during construction
+		$instance = $prop->getValue();
+		$this->assertNull(
+			$instance,
+			'TaskCompletionTriggers constructor must not instantiate WC_Payment_Gateways. '
+			. 'Doing so freezes the gateway list before third-party plugins can register.'
+		);
+
+		$this->deactivateWooCommerceAfterTest();
+	}
+
 	// ========================================
 	// # Logo Upload Tasks Tests
 	// ========================================


### PR DESCRIPTION
## Proposed changes

When the Bluehost plugin is active, third-party WooCommerce payment gateways (Stripe, Braintree, etc.) disappear from the checkout page. Customers see no payment options and can't complete purchases. Deactivating the Bluehost plugin immediately restores them.

Fixes #324 | [PRESS0-4235](https://newfold.atlassian.net/browse/PRESS0-4235)

### Root cause

`TaskCompletionTriggers::register_payment_hooks_and_validators()` calls `\WC_Payment_Gateways::instance()->get_payment_gateway_ids()` synchronously from its constructor. The Newfold module loader fires module callbacks on `after_setup_theme` priority 100, which is *before* `woocommerce_init` (fired at `init` priority 0). That first call to `WC_Payment_Gateways::instance()` triggers `WC_Payment_Gateways::init()`, which applies the `woocommerce_payment_gateways` filter and caches the result. Any gateway plugin that registers via that filter on `woocommerce_init` or later — a standard, common pattern — gets permanently excluded because the cache is already frozen.

Confirmed on a production customer site (`thegolfrulessamaritan.golf`): with the Bluehost plugin active, `stripe` and `stripe_sepa_debit` were missing from `WC()->payment_gateways()->payment_gateways()`. With the plugin deactivated, all 25 gateways appeared. A debug mu-plugin confirmed `WC_Payment_Gateways` was being instantiated during `after_setup_theme` with the Bluehost plugin active, and never instantiated that early without it.

### What this PR does

1. **Removes the early `WC_Payment_Gateways::instance()` call** from `register_payment_hooks_and_validators()`. The constructor no longer touches the WC gateway singleton.

2. **Consolidates hook registration into `register_payment_gateway_hooks()`**, which already runs on `init` priority 20 (safely after `woocommerce_init` at priority 0). This method now registers *both* hook types that were previously split across two code paths:
   - `woocommerce_update_options_payment_gateways_{id}` (WC admin save)
   - `update_option_woocommerce_{id}_settings` (generic option update)

3. **Adds two regression tests:**
   - `test_constructor_does_not_instantiate_payment_gateways_early` — uses reflection to verify the constructor never creates the `WC_Payment_Gateways` singleton. Catches future regressions.
   - `test_register_payment_gateway_hooks_registers_both_hook_types` — verifies both hook types are registered for every gateway after `register_payment_gateway_hooks()` runs.

### Why deferring to init/20 doesn't break anything

The hooks exist to detect when someone saves payment gateway settings in wp-admin. That save happens during an admin POST request, well after `init`. Registering at `init` priority 20 vs `after_setup_theme` makes zero functional difference — the hooks are ready long before any save action could fire.

## Type of Change

#### Production

- [x] Bugfix (non-breaking change which fixes an issue)

**How to reproduce:** Install WooCommerce + WooCommerce Stripe Gateway, configure Stripe, activate the Bluehost plugin, go to checkout — Stripe payment option is missing. Deactivate Bluehost plugin — it reappears.

#### Development

- [x] Tests

## Visual

N/A — server-side hook timing issue, not a UI change. Verified via WP-CLI:

```
# Before fix (Bluehost active): stripe missing
wp eval "print_r(array_keys(WC()->payment_gateways()->payment_gateways()));"
# bacs, cheque, cod, stripe_us_bank_account, ... (no stripe, no stripe_sepa_debit)

# After fix (Bluehost active): stripe present
wp eval "print_r(array_keys(WC()->payment_gateways()->payment_gateways()));"
# bacs, cheque, cod, stripe, stripe_us_bank_account, ..., stripe_sepa_debit, ...
```

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/bluehost/.github/blob/master/.github/contributing.md) doc
- [x] I have viewed my change in a web-browser
- [x] Linting and tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

The same bug was reported in a [previous incident in January/February 2026](https://newfold.atlassian.net/browse/DEVSUP-130672) affecting a customer using Braintree. A working proof-of-concept patch was made at that time but never landed. This PR is the proper fix with tests and production verification.

The Bluehost plugin's Playwright E2E suite (55 passed, 5 skipped, 1 pre-existing flaky in wp-module-solutions) and this module's Codeception wpunit suite (192 tests, 529 assertions) both pass cleanly with this change.