### PR TITLE
Minimally scope permissions in GitHub Actions workflows

### DIFF
--- a/.github/workflows/auto-translate.yml
+++ b/.github/workflows/auto-translate.yml
@@ -12,15 +12,17 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}
   cancel-in-progress: true
 
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
 permissions: {}
 
 jobs:
   translate:
     name: 'Check and update translations'
-    permissions:
-      contents: write
-      pull-requests: write
     uses: newfold-labs/workflows/.github/workflows/reusable-translations.yml@main
+    permissions:
+      contents: write      # Required for the reusable workflow to push translation commits and branches.
+      pull-requests: write # Required for the reusable workflow to create or update translation pull requests.
     with:
       text_domain: 'wp-module-next-steps'
     secrets:

--- a/.github/workflows/auto-translate.yml
+++ b/.github/workflows/auto-translate.yml
@@ -23,6 +23,7 @@ jobs:
     permissions:
       contents: write      # Required for the reusable workflow to push translation commits and branches.
       pull-requests: write # Required for the reusable workflow to create or update translation pull requests.
+    timeout-minutes: 45
     with:
       text_domain: 'wp-module-next-steps'
     secrets:

--- a/.github/workflows/auto-translate.yml
+++ b/.github/workflows/auto-translate.yml
@@ -19,10 +19,10 @@ permissions: {}
 jobs:
   translate:
     name: 'Check and update translations'
-    uses: newfold-labs/workflows/.github/workflows/reusable-translations.yml@main
     permissions:
       contents: write      # Required for the reusable workflow to push translation commits and branches.
       pull-requests: write # Required for the reusable workflow to create or update translation pull requests.
+    uses: newfold-labs/workflows/.github/workflows/reusable-translations.yml@main
     timeout-minutes: 45
     with:
       text_domain: 'wp-module-next-steps'

--- a/.github/workflows/brand-plugin-test-playwright.yml
+++ b/.github/workflows/brand-plugin-test-playwright.yml
@@ -10,10 +10,15 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
   cancel-in-progress: true
 
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
 jobs:
   setup:
     name: Setup
     runs-on: ubuntu-latest
+    permissions: {}
     outputs:
       branch: ${{ steps.extract_branch.outputs.branch }}
     steps:
@@ -27,6 +32,8 @@ jobs:
     name: Bluehost Build and Test Playwright
     needs: setup
     uses: newfold-labs/workflows/.github/workflows/module-plugin-test-playwright.yml@main
+    permissions:
+      contents: read # Required for the reusable workflow to check out the plugin and module repos.
     with:
       module-repo: ${{ github.repository }}
       module-branch: ${{ needs.setup.outputs.branch }}

--- a/.github/workflows/brand-plugin-test-playwright.yml
+++ b/.github/workflows/brand-plugin-test-playwright.yml
@@ -32,9 +32,9 @@ jobs:
   bluehost:
     name: Bluehost Build and Test Playwright
     needs: setup
-    uses: newfold-labs/workflows/.github/workflows/module-plugin-test-playwright.yml@main
     permissions:
       contents: read # Required for the reusable workflow to check out the plugin and module repos.
+    uses: newfold-labs/workflows/.github/workflows/module-plugin-test-playwright.yml@main
     timeout-minutes: 120
     with:
       module-repo: ${{ github.repository }}

--- a/.github/workflows/brand-plugin-test-playwright.yml
+++ b/.github/workflows/brand-plugin-test-playwright.yml
@@ -19,6 +19,7 @@ jobs:
     name: Setup
     runs-on: ubuntu-latest
     permissions: {}
+    timeout-minutes: 5
     outputs:
       branch: ${{ steps.extract_branch.outputs.branch }}
     steps:
@@ -34,6 +35,7 @@ jobs:
     uses: newfold-labs/workflows/.github/workflows/module-plugin-test-playwright.yml@main
     permissions:
       contents: read # Required for the reusable workflow to check out the plugin and module repos.
+    timeout-minutes: 120
     with:
       module-repo: ${{ github.repository }}
       module-branch: ${{ needs.setup.outputs.branch }}

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -10,6 +10,10 @@ on:
     #   - "src/**/*.js"
     #   - "src/**/*.jsx"
 
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
 jobs:
   claude-review:
     # Optional: Filter by PR author
@@ -21,10 +25,10 @@ jobs:
     
     runs-on: ubuntu-latest
     permissions:
-      contents: read
-      pull-requests: read
-      issues: read
-      id-token: write
+      contents: read       # Required to clone the repo.
+      pull-requests: write # Required for gh pr comment in the review prompt.
+      issues: read         # Required for optional gh issue read commands allowed in claude_args.
+      id-token: write      # Required for OIDC token exchange when using Claude Code OAuth.
     
     steps:
       - name: Checkout repository

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -29,6 +29,7 @@ jobs:
       pull-requests: write # Required for gh pr comment in the review prompt.
       issues: read         # Required for optional gh issue read commands allowed in claude_args.
       id-token: write      # Required for OIDC token exchange when using Claude Code OAuth.
+    timeout-minutes: 60
     
     steps:
       - name: Checkout repository

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -10,6 +10,10 @@ on:
   pull_request_review:
     types: [submitted]
 
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
 jobs:
   claude:
     if: |
@@ -19,11 +23,11 @@ jobs:
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
     runs-on: ubuntu-latest
     permissions:
-      contents: read
-      pull-requests: read
-      issues: read
-      id-token: write
-      actions: read # Required for Claude to read CI results on PRs
+      contents: write      # Required to clone and for Claude Code file edits/commits.
+      pull-requests: write # Required for Claude Code pull request comment tooling.
+      issues: write        # Required for Claude Code issue comment tooling.
+      id-token: write      # Required for OIDC token exchange when using Claude Code OAuth.
+      actions: read        # Required for Claude to read CI results on PRs.
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6.0.2

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -28,6 +28,7 @@ jobs:
       issues: write        # Required for Claude Code issue comment tooling.
       id-token: write      # Required for OIDC token exchange when using Claude Code OAuth.
       actions: read        # Required for Claude to read CI results on PRs.
+    timeout-minutes: 60
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6.0.2

--- a/.github/workflows/codecoverage-main.yml
+++ b/.github/workflows/codecoverage-main.yml
@@ -13,12 +13,14 @@ on:
       - main
   workflow_dispatch:
 
-permissions:
-  contents: read
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
 
 jobs:
   get-repo-name:
     runs-on: ubuntu-latest
+    permissions: {}
     outputs:
       repository-name: ${{ steps.repo-name.outputs.name }}
     steps:
@@ -28,10 +30,10 @@ jobs:
 
   codecoverage:
     needs: get-repo-name
-    permissions:
-      contents: write
-      pull-requests: write
     uses: newfold-labs/workflows/.github/workflows/reusable-codecoverage.yml@main
+    permissions:
+      contents: write      # Required for the reusable workflow to push coverage artifacts to gh-pages.
+      pull-requests: write # Required for the reusable workflow to post coverage comments on pull requests.
     with:
       php-versions: '["7.4", "8.0", "8.1", "8.2", "8.3", "8.4"]'
       coverage-php-version: '7.4'

--- a/.github/workflows/codecoverage-main.yml
+++ b/.github/workflows/codecoverage-main.yml
@@ -21,6 +21,7 @@ jobs:
   get-repo-name:
     runs-on: ubuntu-latest
     permissions: {}
+    timeout-minutes: 10
     outputs:
       repository-name: ${{ steps.repo-name.outputs.name }}
     steps:
@@ -34,6 +35,7 @@ jobs:
     permissions:
       contents: write      # Required for the reusable workflow to push coverage artifacts to gh-pages.
       pull-requests: write # Required for the reusable workflow to post coverage comments on pull requests.
+    timeout-minutes: 90
     with:
       php-versions: '["7.4", "8.0", "8.1", "8.2", "8.3", "8.4"]'
       coverage-php-version: '7.4'

--- a/.github/workflows/codecoverage-main.yml
+++ b/.github/workflows/codecoverage-main.yml
@@ -31,10 +31,10 @@ jobs:
 
   codecoverage:
     needs: get-repo-name
-    uses: newfold-labs/workflows/.github/workflows/reusable-codecoverage.yml@main
     permissions:
       contents: write      # Required for the reusable workflow to push coverage artifacts to gh-pages.
       pull-requests: write # Required for the reusable workflow to post coverage comments on pull requests.
+    uses: newfold-labs/workflows/.github/workflows/reusable-codecoverage.yml@main
     timeout-minutes: 90
     with:
       php-versions: '["7.4", "8.0", "8.1", "8.2", "8.3", "8.4"]'

--- a/.github/workflows/lint-checker-php.yml
+++ b/.github/workflows/lint-checker-php.yml
@@ -14,10 +14,16 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
   cancel-in-progress: true
 
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
 jobs:
   phpcs:
     name: Run PHP Code Sniffer
     runs-on: ubuntu-latest
+    permissions:
+      contents: read # Required to clone the repo.
     steps:
 
       - name: Checkout

--- a/.github/workflows/lint-checker-php.yml
+++ b/.github/workflows/lint-checker-php.yml
@@ -24,6 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read # Required to clone the repo.
+    timeout-minutes: 30
     steps:
 
       - name: Checkout

--- a/.github/workflows/newfold-prep-release.yml
+++ b/.github/workflows/newfold-prep-release.yml
@@ -21,10 +21,10 @@ jobs:
   # This job runs the newfold module-prep-release workflow for this module.
   prep-release:
     name: Prepare Release
-    uses: newfold-labs/workflows/.github/workflows/reusable-module-prep-release.yml@main
     permissions:
       contents: write      # Required for the reusable workflow to push release prep commits and branches.
       pull-requests: write # Required for the reusable workflow to open the release pull request.
+    uses: newfold-labs/workflows/.github/workflows/reusable-module-prep-release.yml@main
     timeout-minutes: 60
     with:
       module-repo: ${{ github.repository }}

--- a/.github/workflows/newfold-prep-release.yml
+++ b/.github/workflows/newfold-prep-release.yml
@@ -25,6 +25,7 @@ jobs:
     permissions:
       contents: write      # Required for the reusable workflow to push release prep commits and branches.
       pull-requests: write # Required for the reusable workflow to open the release pull request.
+    timeout-minutes: 60
     with:
       module-repo: ${{ github.repository }}
       module-branch: 'main'

--- a/.github/workflows/newfold-prep-release.yml
+++ b/.github/workflows/newfold-prep-release.yml
@@ -23,8 +23,8 @@ jobs:
     name: Prepare Release
     uses: newfold-labs/workflows/.github/workflows/reusable-module-prep-release.yml@main
     permissions:
-        contents: write
-        pull-requests: write
+      contents: write      # Required for the reusable workflow to push release prep commits and branches.
+      pull-requests: write # Required for the reusable workflow to open the release pull request.
     with:
       module-repo: ${{ github.repository }}
       module-branch: 'main'

--- a/.github/workflows/satis-update.yml
+++ b/.github/workflows/satis-update.yml
@@ -5,10 +5,15 @@ on:
     types:
       - created
 
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
 jobs:
   webhook:
     name: Send Webhook
     runs-on: ubuntu-latest
+    permissions: {}
     steps:
 
       - name: Set Package

--- a/.github/workflows/satis-update.yml
+++ b/.github/workflows/satis-update.yml
@@ -14,6 +14,7 @@ jobs:
     name: Send Webhook
     runs-on: ubuntu-latest
     permissions: {}
+    timeout-minutes: 10
     steps:
 
       - name: Set Package


### PR DESCRIPTION
This updates the GitHub Actions workflow files to:

- Grant minimally-scoped permissions to each job to adhere to the principle of least privilege
- Specify a timeout on each job to prevent runaway processes consuming too many minutes (the default is 360)

Once this PR is merged, [the Settings -> Actions -> Workflow permissions setting](https://github.com/WordPress/wordpress-playground/settings/actions) can be changed by a repo admin to "Read repository contents and packages permissions".

For more information, see [PRESS11-470](https://newfold.atlassian.net/browse/PRESS11-470).

## References

- https://docs.github.com/en/actions/reference/security/secure-use
- https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#jobsjob_idtimeout-minutes

## Use of AI

Cursor was used with (Claude Opus 4.7 and Composer 2.0 at varying points) to analyze the repository and make the initial changes.

When this PR is marked "ready for review" it means that I have manually reviewed all permissions and timeouts that were changed and made any necessary adjustments.

As a part of the analysis, the following summary was created:

## Status

| Field | Value |
|---|---|
| Workflows scanned | 8 (`auto-translate.yml`, `brand-plugin-test-playwright.yml`, `claude-code-review.yml`, `claude.yml`, `codecoverage-main.yml`, `lint-checker-php.yml`, `newfold-prep-release.yml`, `satis-update.yml`) |
| Branch | `add/scoped-workflow-permissions` (already existed — no further changes applied on this rerun) |
| Permissions commit | `8c1f306b` |
| Timeouts commit | `3d2769ab` |


## Top-level `permissions: {}`

| Category | Entry |
|---|---|
| Workflows that were missing the top-level `permissions: {}` directive (added in this run): | `satis-update.yml` |
| Workflows that were missing the top-level `permissions: {}` directive (added in this run): | `lint-checker-php.yml` |
| Workflows that were missing the top-level `permissions: {}` directive (added in this run): | `codecoverage-main.yml` (replaced non-empty workflow-level permissions with the audited default-empty pattern) |
| Workflows that were missing the top-level `permissions: {}` directive (added in this run): | `brand-plugin-test-playwright.yml` |
| Workflows that were missing the top-level `permissions: {}` directive (added in this run): | `claude.yml` |
| Workflows that were missing the top-level `permissions: {}` directive (added in this run): | `claude-code-review.yml` |
| Workflows updated for the mandated comment preamble only (bare `permissions: {}` existed before): | `auto-translate.yml` |


## Job-level `permissions:` additions

| Workflow file | Summary | Job | Permissions / notes |
|---|---|---|---|
| satis-update.yml | 1 job was missing a scoped `permissions:` directive | webhook | `permissions: {}` [3] |
| lint-checker-php.yml | 1 job was missing a scoped `permissions:` directive | phpcs | `contents: read` [3] |
| codecoverage-main.yml | 1 job was missing a scoped `permissions:` directive | get-repo-name | `permissions: {}` [3] |
| brand-plugin-test-playwright.yml | 2 jobs were missing a scoped `permissions:` directive | setup | `permissions: {}` [3] |
| brand-plugin-test-playwright.yml | 2 jobs were missing a scoped `permissions:` directive | bluehost | `contents: read` [3] |


## Permissions corrections (previously incorrect)

| # | Correction |
|---:|---|
| 1 | `codecoverage-main.yml` :: workflow: BEFORE `contents: read` at workflow scope -> AFTER default-deny `{}` stanza plus required comment preamble -- align with audited default posture; scope belongs on jobs -- [3] |
| 2 | `codecoverage-main.yml` :: `codecoverage`: BEFORE standalone `permissions` block before `uses` without per-permission rationales -> AFTER `uses` placement with minimally scoped `contents: write`, `pull-requests: write` and inline rationales keyed to callee behavior -- [3] |
| 3 | `claude.yml` :: `claude`: BEFORE `contents/read`, `pull-requests/read`, `issues/read` (+ `actions: read`) -> AFTER `contents/write`, `pull-requests/write`, `issues/write`, `actions: read` -- match upstream `anthropics/claude-code-action` baseline for interactive edits and PR/issue participation -- [3] |
| 4 | `claude-code-review.yml` :: `claude-review`: BEFORE `pull-requests: read` alongside `contents: read`, `issues: read`, `id-token: write` -> AFTER same except `pull-requests: write` -- required for Bash `gh pr comment` mandated by workflow prompt -- [3] |
| 5 | `newfold-prep-release.yml` :: `prep-release`: BEFORE `contents: write` / `pull-requests: write` without inline rationales -> AFTER same scopes with explanatory trailing comments plus YAML normalization -- clarify least-privilege rationale for callee -- [3] |
| 6 | `auto-translate.yml` :: `translate`: BEFORE permissions ahead of reusable `uses` without inline rationales -> AFTER `permissions` immediately following `uses` with aligned trailing-comment rationales -- align with audited layout and callee needs -- [3] |


## `timeout-minutes` additions

| Workflow | Job | Minutes / action | Rationale |
|---|---|---|---|
| satis-update.yml | webhook | `10` | release-tag webhook finishes quickly once `repository_dispatch` is accepted; guards against stalled runners without consuming excessive minutes. |
| lint-checker-php.yml | phpcs | `30` | Composer install plus PHPCS on diff-gated PHP changes should complete well under typical PR iteration targets. |
| codecoverage-main.yml | get-repo-name | `10` | single-step naming helper only; short limit prevents indefinite hangs around runner allocation. |
| codecoverage-main.yml | codecoverage | `90` | matrix across several PHP versions, Composer, Codeception/wpunit, merges, gh-pages pushes, and PR commentary can run long versus default caps. |
| claude.yml | claude | `60` | conversational agent runs can spike on tooling and network; limit bounds worst-case Claude Code sessions. |
| claude-code-review.yml | claude-review | `60` | same rationale as conversational review workloads with repository reads and scripted `gh` calls. |
| brand-plugin-test-playwright.yml | setup | `5` | branch extraction completes immediately; avoids stuck queue slots. |
| brand-plugin-test-playwright.yml | bluehost | `120` | delegated Playwright + brand-plugin installs often exceed lint-style jobs; accommodates nested reusable runtime. |
| newfold-prep-release.yml | prep-release | `60` | versioning, Composer/NPM tooling, branching, pushing, and `gh pr create` should stay bounded while allowing toolchain variance. |
| auto-translate.yml | translate | `45` | aligns with sibling reusable workflows that perform gettext automation and PR orchestration steps. |


## Notes / blockers

| # | Note |
|---:|---|
| 1 | Third-party and organization reusable workflows (`newfold-labs/workflows@main`) were cross-checked briefly against locally available copies (`module-plugin-test-playwright.yml`, `reusable-codecoverage.yml`, `reusable-module-prep-release.yml`, `reusable-translations.yml`); upstream drift on `@main` should be revalidated before merge by skimming changelog or pinned SHAs when policy allows. |
| 2 | `anthropics/claude-code-action@v1` resolves a moving tag; if behavior changes materially, rerun the documentation-based permission review pinned to concrete release notes. |
| 3 | `peter-evans/repository-dispatch` dispatches exclusively with `secrets.WEBHOOK_TOKEN`; revisit if the PAT gains narrow scopes differing from assumptions. |
| 4 | Instructions (`DO NOT publish`) respected: neither `git push` nor PR creation attempted. |
| 5 | [REDACTED] |


