### PR TITLE
ci: add Cloudflare AI Gateway PR review via central workflows

### DIFF
--- a/.github/workflows/ai-code-review.yml
+++ b/.github/workflows/ai-code-review.yml
@@ -1,0 +1,35 @@
+##
+# AI pull request review via Cloudflare AI Gateway (central reusable workflow).
+# Posts a sticky PR comment and optional Actions check annotations (file/line) from the model JSON.
+#
+# Secrets (repository or organization): CLOUDFLARE_ACCOUNT_ID, CLOUDFLARE_AI_GATEWAY_TOKEN
+# Variable (organization or repository): CLOUDFLARE_AI_GATEWAY_ID — gateway id path segment (not a secret).
+#
+# Pin `uses: ...@main` (or a commit SHA). Set `prompts_ref` to the same ref (e.g. main).
+##
+name: AI Code Review
+
+on:
+  pull_request:
+    types: [ opened, synchronize, reopened, ready_for_review ]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
+  cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+  review:
+    if: github.event.pull_request.draft == false && github.event.pull_request.head.repo.fork == false
+    name: Review PR diff
+    uses: newfold-labs/workflows/.github/workflows/reusable-code-review.yml@main
+    with:
+      prompts_ref: main
+    permissions:
+      contents: read
+      pull-requests: write
+      checks: write
+    secrets:
+      CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+      CLOUDFLARE_AI_GATEWAY_TOKEN: ${{ secrets.CLOUDFLARE_AI_GATEWAY_TOKEN }}

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,6 +12,10 @@ on:
 
 jobs:
   claude-review:
+    # Disabled: automated PR reviews use `.github/workflows/ai-code-review.yml` (Cloudflare AI Gateway).
+    # Set to `true` to re-enable this job as a fallback.
+    if: false
+
     # Optional: Filter by PR author
     if: |
       github.actor != 'dependabot[bot]'


### PR DESCRIPTION
- Add ai-code-review.yml calling newfold-labs/workflows reusable workflow
- Disable automatic Claude Code Review job (if: false) for backup use
